### PR TITLE
Enhance RHEL suporting ability

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,6 @@
   when: network_bridge_interfaces is defined
   register: bridge_port_result
 
-
 # Restart Network Interfaces (deconfigurate & reconfigurate interfaces) 
 - include: restartscript.yml
   when: network_allow_service_restart and ansible_os_family == 'Debian'
@@ -63,4 +62,3 @@
   service: name=network state=restarted
   when: network_allow_service_restart and ansible_os_family == 'RedHat'
  
-

--- a/templates/RedHat_bond_options.j2
+++ b/templates/RedHat_bond_options.j2
@@ -1,0 +1,11 @@
+BONDING_OPTS="mode={{ item.bond_mode }} miimon={{ item.bond_miimon|default(100) }}
+{%- if item.bond_downdelay is defined %}
+ downdelay={{ item.bond_downdelay }}
+{%- endif -%}
+{%- if item.bond_updelay is defined %}
+ updelay={{ item.bond_updelay }}
+{%- endif -%}
+{%- if item.bond_primary is defined %}
+ primary={{ item.bond_primary }}
+{%- endif -%}
+"

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -2,20 +2,24 @@
 {% if item.bootproto != 'dhcp' %}
 DEVICE={{ item.device }}
 USERCTL=no
-BOOTPROTO=none
+BOOTPROTO=static
+BONDING_MASTER=yes
+TYPE=Bond
+DEFROUTE={{ item.defroute | default("yes")| bool | ternary("yes", "no")  }}
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}
 {% if item.address is defined %}
 IPADDR={{ item.address }}
 {% endif %}
-{% if item.onboot is defined %}
-ONBOOT={{ item.onboot|default("yes") }}
-{% endif %}
+ONBOOT={{ item.onboot | default("yes") | bool | ternary("yes", "no") }}
 {% if item.netmask is defined %}
 NETMASK={{ item.netmask }}
 {% endif %}
 {% if item.gateway is defined %}
 GATEWAY={{ item.gateway }}
 {% endif %}
-BONDING_OPTS="mode={{ item.bond_mode }} miimon={{ item.bond_miimon|default(100) }} {{ item.bond_extra_opts|default('') }}"
+{% include "RedHat_bond_options.j2" %}
 {% endif %}
 {% if item.dns_nameservers is defined %}
 {% for dns_nameserver in item.dns_nameservers %}
@@ -25,10 +29,14 @@ DNS{{ loop.index }}={{ dns_nameserver }}
 
 {% if item.bootproto == 'dhcp' %}
 DEVICE={{ item.device }}
-BONDING_OPTS="mode={{ item.bond_mode }} miimon={{ item.bond_miimon|default(100) }} {{ item.bond_extra_opts|default('') }}"
+{% include "RedHat_bond_options.j2" %}
 USERCTL=no
-ONBOOT={{ item.onboot|default("yes") }}
+ONBOOT={{ item.onboot | default("yes") | bool | ternary("yes", "no") }}
 BOOTPROTO=dhcp
+TYPE=Bond
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}
 {% endif %}
 
 {% if item.nm_controlled is defined %}

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -13,3 +13,7 @@ NM_CONTROLLED={{ item.nm_controlled }}
 DEFROUTE={{ item.defroute }}
 {% endif %}
 
+{% if item.0.mtu is defined %}
+MTU={{ item.0.mtu }}
+{% endif %}
+

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -3,6 +3,9 @@
 DEVICE={{ item.device }}
 TYPE=Bridge
 BOOTPROTO=none
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}
 {% if item.stp is defined %}
 STP={{ item.stp }}
 {% endif %}
@@ -29,6 +32,9 @@ DNS{{ loop.index }}={{ dns_nameserver }}
 DEVICE={{ item.device }}
 TYPE=bridge
 BOOTPROTO=dhcp
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}
 {% if item.stp is defined %}
 STP={{ item.stp }}
 {% endif %}

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -3,4 +3,6 @@ DEVICE={{ item.1 }}
 TYPE=Ethernet
 BOOTPROTO=none
 BRIDGE={{ item.0.device }}
-
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -1,12 +1,16 @@
 
 {% if item.bootproto == 'static' %}
 DEVICE={{ item.device }}
-BOOTPROTO=none
+BOOTPROTO=static
+{% if item.defroute is defined %}
+DEFROUTE={{ item.defroute }}
+{% endif %}
 {% if item.address is defined %}
 IPADDR={{ item.address }}
 {% endif %}
-{% if item.onboot is defined %}
-ONBOOT={{ item.onboot }}
+ONBOOT={{ item.onboot | default("yes") }}
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
 {% endif %}
 {% if item.netmask is defined %}
 NETMASK={{ item.netmask }}
@@ -14,8 +18,8 @@ NETMASK={{ item.netmask }}
 {% if item.gateway is defined %}
 GATEWAY={{ item.gateway }}
 {% endif %}
-{% if item.vlan is defined %}
-VLAN=yes
+{% if item.vlan is defined and item.vlan | bool %}
+{% include  "ethernet_RedHat_vlan_options.j2" %}
 {% endif %}
 {% endif %}
 {% if item.dns_nameservers is defined %}
@@ -30,6 +34,13 @@ DNS{{ loop.index }}={{ dns_nameserver }}
 {% if item.bootproto == 'dhcp' %}
 DEVICE={{ item.device }}
 BOOTPROTO=dhcp
+ONBOOT={{ item.onboot | default("yes") }}
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}
+{% if item.vlan is defined and item.vlan | bool %}
+{% include  "ethernet_RedHat_vlan_options.j2" %}
+{% endif %}
 {% endif %}
 
 {% if item.nm_controlled is defined %}

--- a/templates/ethernet_RedHat_vlan_options.j2
+++ b/templates/ethernet_RedHat_vlan_options.j2
@@ -1,0 +1,15 @@
+VLAN=yes
+TYPE=Vlan
+{% if item.vlan_physdev is defined %}
+PHYSDEV={{ item.vlan_physdev }}
+{% else %}
+PHYSDEV={{ item.device.rpartition('.')[0] }}
+{% endif %}
+{% if item.vlan_id is defined %}
+VLAN_ID={{ item.vlan_id }}
+{% else %}
+VLAN_ID={{ item.device.rpartition('.')[2] }}
+{% endif %}
+{% if item.reorder_hdr is defined %}
+REORDER_HDR={{ item.reorder_hdr }}
+{% endif %}


### PR DESCRIPTION
1. Move "RedHat_bond_options" to separate template
2. Support "DEFROUTE" in RHEL interface template
3. Support "MTU" in RHEL interface template
4. Create 'ethernet_RedHat_vlan_options' template
5. Mark BOOTPROTO=static if it's using static setup
