### PR TITLE
Allow set "defroute" and "onboot" keys use boolean type

### DIFF
--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -5,14 +5,9 @@ USERCTL=no
 BOOTPROTO=static
 BONDING_MASTER=yes
 TYPE=Bond
-DEFROUTE={{ item.defroute | default("yes")| bool | ternary("yes", "no")  }}
-{% if item.mtu is defined %}
-MTU={{ item.mtu }}
-{% endif %}
 {% if item.address is defined %}
 IPADDR={{ item.address }}
 {% endif %}
-ONBOOT={{ item.onboot | default("yes") | bool | ternary("yes", "no") }}
 {% if item.netmask is defined %}
 NETMASK={{ item.netmask }}
 {% endif %}
@@ -31,12 +26,12 @@ DNS{{ loop.index }}={{ dns_nameserver }}
 DEVICE={{ item.device }}
 {% include "RedHat_bond_options.j2" %}
 USERCTL=no
-ONBOOT={{ item.onboot | default("yes") | bool | ternary("yes", "no") }}
 BOOTPROTO=dhcp
 TYPE=Bond
-{% if item.mtu is defined %}
-MTU={{ item.mtu }}
 {% endif %}
+
+{% if item.onboot is defined %}
+ONBOOT={{ item.onboot | bool | ternary("yes", "no") }}
 {% endif %}
 
 {% if item.nm_controlled is defined %}
@@ -44,7 +39,7 @@ NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
 {% if item.defroute is defined %}
-DEFROUTE={{ item.defroute }}
+DEFROUTE={{ item.defroute | bool | ternary("yes", "no") }}
 {% endif %}
 
 {% if item.mtu is defined %}
@@ -58,4 +53,3 @@ BONDING_MASTER={{ item.bonding_master }}
 {% if item.bridge is defined %}
 BRIDGE={{ item.bridge }}
 {% endif %}
-

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -10,7 +10,7 @@ NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
 {% if item.defroute is defined %}
-DEFROUTE={{ item.defroute }}
+DEFROUTE={{ item.defroute | bool | ternary("yes", "no") }}
 {% endif %}
 
 {% if item.0.mtu is defined %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -12,9 +12,6 @@ STP={{ item.stp }}
 {% if item.address is defined %}
 IPADDR={{ item.address }}
 {% endif %}
-{% if item.onboot is defined %}
-ONBOOT={{ item.onboot }}
-{% endif %}
 {% if item.netmask is defined %}
 NETMASK={{ item.netmask }}
 {% endif %}
@@ -40,6 +37,10 @@ STP={{ item.stp }}
 {% endif %}
 {% endif %}
 
+{% if item.onboot is defined %}
+ONBOOT={{ item.onboot | bool | ternary("yes", "no") }}
+{% endif %}
+
 {% if item.nm_controlled is defined %}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
@@ -60,7 +61,7 @@ IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
 {% endif %}
 
 {% if item.defroute is defined %}
-DEFROUTE={{ item.defroute }}
+DEFROUTE={{ item.defroute | bool | ternary("yes", "no") }}
 {% endif %}
 
 {% if item.mtu is defined %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -2,15 +2,8 @@
 {% if item.bootproto == 'static' %}
 DEVICE={{ item.device }}
 BOOTPROTO=static
-{% if item.defroute is defined %}
-DEFROUTE={{ item.defroute }}
-{% endif %}
 {% if item.address is defined %}
 IPADDR={{ item.address }}
-{% endif %}
-ONBOOT={{ item.onboot | default("yes") }}
-{% if item.mtu is defined %}
-MTU={{ item.mtu }}
 {% endif %}
 {% if item.netmask is defined %}
 NETMASK={{ item.netmask }}
@@ -27,17 +20,13 @@ GATEWAY={{ item.gateway }}
 DNS{{ loop.index }}={{ dns_nameserver }}
 {% endfor %}
 {% endif %}
-+{% if item.hwaddress is defined%}
-+HWADDR={{ item.hwaddress }}
-+{% endif %}
+{% if item.hwaddress is defined%}
+HWADDR={{ item.hwaddress }}
+{% endif %}
 
 {% if item.bootproto == 'dhcp' %}
 DEVICE={{ item.device }}
 BOOTPROTO=dhcp
-ONBOOT={{ item.onboot | default("yes") }}
-{% if item.mtu is defined %}
-MTU={{ item.mtu }}
-{% endif %}
 {% if item.vlan is defined and item.vlan | bool %}
 {% include  "ethernet_RedHat_vlan_options.j2" %}
 {% endif %}
@@ -62,8 +51,12 @@ IPV6ADDR={{ item.ipv6_address }}
 IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
 {% endif %}
 
+{% if item.onboot is defined %}
+ONBOOT={{ item.onboot | bool | ternary("yes", "no") }}
+{% endif %}
+
 {% if item.defroute is defined %}
-DEFROUTE={{ item.defroute }}
+DEFROUTE={{ item.defroute | bool | ternary("yes", "no") }}
 {% endif %}
 
 {% if item.mtu is defined %}


### PR DESCRIPTION
Variable like "DEFROUTE" and "ONBOOT" only accpet "yes" and "no",
if we define the variable as boolean, it will be templated as
True/False. Here adds filters for it.
Also cleans duplicated entries from previous cherry-pick
