### PR TITLE
Ported back to ansible 1.x (1.9 specifically).

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Note: The values for the list are listed in the examples below.
 Examples
 --------
 
-For all network configurations, it is possible to use CIDR or IPv4 Address notation. 
+For all network configurations, it is possible to use CIDR or IPv4 Address notation.
 I recomend the use of CIDR, because it helps to get a simpler configuration and it
 is the only way for IPv6 Addresses.
 
@@ -51,8 +51,8 @@ IPv4 Example with CIDR notation:
 
       cidr: 192.168.10.18/24
       # OPTIONAL: specify a gateway for that network, or auto for network+1
-      gateway: auto 
- 
+      gateway: auto
+
 IPv4 Example with classic IPv4:
 
       address: 192.168.10.18
@@ -65,14 +65,14 @@ If you want to use a different MAC Address for your Interface, you can simply ad
 
       hwaddress: aa:bb:cc:dd:ee:ff
 
-On some rare occasion it might be good to set whatever option you like. Therefore it 
+On some rare occasion it might be good to set whatever option you like. Therefore it
 is possible to use
 
       options:
           - "up /execute/my/command"
           - "down /execute/my/other/command"
 
-and the IPv6 version 
+and the IPv6 version
 
       ipv6_options:
           - "up /execute/my/command"
@@ -89,7 +89,7 @@ define static routes and a gateway.
            - device: eth1
              bootproto: static
              cidr: 192.168.10.18/24
-             gateway: auto 
+             gateway: auto
              route:
               - network: 192.168.200.0
                 netmask: 255.255.255.0
@@ -102,7 +102,7 @@ define static routes and a gateway.
 
 Note: it is not required to add routes, default route will be added automatically.
 
-2) Configure a bridge interface with multiple NIcs added to the bridge. 
+2) Configure a bridge interface with multiple NIcs added to the bridge.
 
     - hosts: myhost
       roles:
@@ -114,7 +114,7 @@ Note: it is not required to add routes, default route will be added automaticall
               bridge_ports: [eth1, eth2]
 
               # Optional values
-              bridge_ageing: 300 
+              bridge_ageing: 300
               bridge_bridgeprio: 32768
               bridge_fd: 15
               bridge_gcint: 4
@@ -237,8 +237,8 @@ and routed updated.
 
 Note: Ansible needs network connectivity throughout the playbook process, you
 may need to have a control interface that you do *not* modify using this
-method while changeing IP Addresses so that Ansible has a stable connection 
-to configure the target systems. All network changes are done within a single 
+method while changeing IP Addresses so that Ansible has a stable connection
+to configure the target systems. All network changes are done within a single
 generated script and network connectivity is only lost for few seconds.
 
 
@@ -260,4 +260,4 @@ based on role from Benno Joy
 Improvements from some other GIT Forks
 
 Debian Upgrades by Martin Verges, First Colo GmbH
-
+RedHat Upgrades by Wei Tie, Cisco Systems, Inc.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: "Benno Joy, Martin Verges"
   company: "AnsibleWorks, First Colo GmbH"
   license: "Simplified BSD License"
-  min_ansible_version: 2.0 
+  min_ansible_version: 1.9
   platforms:
   - name: Debian
     versions:
@@ -23,4 +23,3 @@ galaxy_info:
     - networking
     - system
 dependencies: []
-  

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,25 +1,18 @@
-
 ---
+# Debian stuff (mostly tested)
+- name: Install the required packages in Debian derivatives
+  apt: name={{ item }} state=installed
+  with_items: "{{ network_pkgs }}"
+  environment: "{{ env }}"
+  when: network_check_packages
 
-# Debian stuff (mostly tested) 
-  - block:
-    - name: Install the required packages in Debian derivatives
-      apt: name={{ item }} state=installed
-      with_items: "{{ network_pkgs }}"
-      environment: "{{ env }}"
-      when: network_check_packages
+- name: Make sure the include line is there in interfaces file
+  lineinfile: >
+     regexp="^source\ {{ net_path | regex_escape() }}/\*"
+     line="source {{ net_path }}/*"
+     dest=/etc/network/interfaces
+     state=present
+     insertafter=EOF
 
-    - name: Make sure the include line is there in interfaces file
-      lineinfile: >
-         regexp="^source\ {{ net_path | regex_escape() }}/\*"
-         line="source {{ net_path }}/*"
-         dest=/etc/network/interfaces
-         state=present
-         insertafter=EOF
-
-    - name: Create the directory for interface cfg files
-      file: path={{ net_path }} state=directory
-
-    when: ansible_os_family == "Debian"
-
-
+- name: Create the directory for interface cfg files
+  file: path={{ net_path }} state=directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
-
 ---
-
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
 # RedHat specific stuff
 - include: redhat.yml
+  when: ansible_os_family == 'RedHat'
 # Debian/Ubuntu specific stuff
 - include: debian.yml
+  when: ansible_os_family == "Debian"
 
 # Create configuration files in the net_path for ethernet, vlan, bond and bridge interfaces
 - name: Create the network configuration file for ethernet devices
@@ -54,11 +54,10 @@
   when: network_bridge_interfaces is defined
   register: bridge_port_result
 
-# Restart Network Interfaces (deconfigurate & reconfigurate interfaces) 
+# Restart Network Interfaces (deconfigurate & reconfigurate interfaces)
 - include: restartscript.yml
   when: network_allow_service_restart and ansible_os_family == 'Debian'
 
 - name: Restart on RedHat Systems
   service: name=network state=restarted
   when: network_allow_service_restart and ansible_os_family == 'RedHat'
- 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,33 +1,26 @@
-
 ---
 # RedHat stuff (needs testing)
+- name: Install the required  packages in Redhat derivatives
+  yum: name={{ item }} state=installed
+  with_items: "{{ network_pkgs }}"
+  when: network_check_packages
 
-  - block:
-    - name: Install the required  packages in Redhat derivatives
-      yum: name={{ item }} state=installed
-      with_items: "{{ network_pkgs }}"
-      when: network_check_packages
+- name: Write configuration files for rhel route configuration with vlan
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_ether_interfaces is defined and item.route is defined
 
-    - name: Write configuration files for rhel route configuration with vlan
-      template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
-      with_items: "{{ network_vlan_interfaces }}"
-      when: network_ether_interfaces is defined and item.route is defined
+- name: Write configuration files for rhel route configuration
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  with_items: "{{ network_ether_interfaces }}"
+  when: network_ether_interfaces is defined and item.route is defined
 
-    - name: Write configuration files for rhel route configuration
-      template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
-      with_items: "{{ network_ether_interfaces }}"
-      when: network_ether_interfaces is defined and item.route is defined
+- name: Write configuration files for route configuration
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  with_items: "{{ network_bond_interfaces }}"
+  when: network_bond_interfaces is defined and item.route is defined
 
-    - name: Write configuration files for route configuration
-      template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
-      with_items: "{{ network_bond_interfaces }}"
-      when: network_bond_interfaces is defined and item.route is defined 
-
-    - name: Write configuration files for rhel route configuration
-      template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
-      with_items: "{{ network_bridge_interfaces }}"
-      when: network_bridge_interfaces is defined and item.route is defined
-
-    when: ansible_os_family == 'RedHat'
-
-
+- name: Write configuration files for rhel route configuration
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
+  with_items: "{{ network_bridge_interfaces }}"
+  when: network_bridge_interfaces is defined and item.route is defined

--- a/tasks/restartscript.yml
+++ b/tasks/restartscript.yml
@@ -1,79 +1,75 @@
-  
+
 ---
 # Restart interfaces to load new configuration
 #
-# we had a lot of problems with lost connectivity, therefore we changed the
+# We had a lot of problems with lost connectivity, therefore we changed the
 # role to use a script for network reconfiguration.
 # Tested on Debian Jessie / Ubuntu 14.04 LTS and with Ethernet, Bonding Interfaces
 
-- block:
-  - name: Create temporary interface script for seamless network reload
-    shell: mktemp
-    register: mktemp_script
-  
-  - lineinfile: line="{{ item }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF
-    with_items:
-      - "ifdown "
-      - "sleep 1"
-      - "ifup "
-  
-  # Shutdown current network configuration
-  - lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
-    with_items: "{{ ether_result.results }}"
-    when: ether_result is defined and 'results' in ether_result and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.1 }}" dest={{ mktemp_script.stdout }} state=present  insertafter=EOF backrefs=True regexp='(ifdown .*)'
-    with_items: "{{ bond_port_result.results }}"
-    when: bond_port_result is defined and 'results' in bond_port_result and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
-    with_items: "{{ bond_result.results }}"
-    when: bond_result is defined and 'results' in bond_result and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
-    with_items: "{{ vlan_result.results }}"
-    when: vlan_result is defined and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
-    with_items: "{{ bridge_result.results }}"
-    when: bridge_result is defined and 'results' in bridge_result and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.1 }};" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
-    with_items: "{{ bridge_port_result.results }}"
-    when: bridge_port_result is defined and 'results' in bridge_port_result and item.changed
-  
-  # Start new network configuration
-  - lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
-    with_items: "{{ ether_result.results }}"
-    when: ether_result is defined and 'results' in ether_result and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.1 }}" dest={{ mktemp_script.stdout }} state=present  insertafter=EOF backrefs=True regexp='(ifup .*)'
-    with_items: "{{ bond_port_result.results }}"
-    when: bond_port_result is defined and 'results' in bond_port_result and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
-    with_items: "{{ bond_result.results }}"
-    when: bond_result is defined and 'results' in bond_result and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
-    with_items: "{{ vlan_result.results }}"
-    when: vlan_result is defined and item.changed
-  
-  - lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
-    with_items: "{{ bridge_result.results }}"
-    when: bridge_result is defined and 'results' in bridge_result and item.changed
-   
-  - lineinfile: line="\1 {{ item.item.1 }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
-    with_items: "{{ bridge_port_result.results }}"
-    when: bridge_port_result is defined and 'results' in bridge_port_result and item.changed
-  
-  # Execute configuration change
-  - name: Execute Network Restart
-    shell: bash {{ mktemp_script.stdout }} | true
-  
-  # Cleanup
-  - name: Cleanup Network Restart script
-    file: path={{ mktemp_script.stdout }} state=absent
+- name: Create temporary interface script for seamless network reload
+  shell: mktemp
+  register: mktemp_script
 
-  when: network_allow_service_restart and ansible_os_family == 'Debian'
-  
+- lineinfile: line="{{ item }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF
+  with_items:
+    - "ifdown "
+    - "sleep 1"
+    - "ifup "
+
+# Shutdown current network configuration
+- lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
+  with_items: "{{ ether_result.results }}"
+  when: ether_result is defined and 'results' in ether_result and item.changed
+
+- lineinfile: line="\1 {{ item.item.1 }}" dest={{ mktemp_script.stdout }} state=present  insertafter=EOF backrefs=True regexp='(ifdown .*)'
+  with_items: "{{ bond_port_result.results }}"
+  when: bond_port_result is defined and 'results' in bond_port_result and item.changed
+
+- lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
+  with_items: "{{ bond_result.results }}"
+  when: bond_result is defined and 'results' in bond_result and item.changed
+
+- lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
+  with_items: "{{ vlan_result.results }}"
+  when: vlan_result is defined and item.changed
+
+- lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
+  with_items: "{{ bridge_result.results }}"
+  when: bridge_result is defined and 'results' in bridge_result and item.changed
+
+- lineinfile: line="\1 {{ item.item.1 }};" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifdown .*)'
+  with_items: "{{ bridge_port_result.results }}"
+  when: bridge_port_result is defined and 'results' in bridge_port_result and item.changed
+
+# Start new network configuration
+- lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
+  with_items: "{{ ether_result.results }}"
+  when: ether_result is defined and 'results' in ether_result and item.changed
+
+- lineinfile: line="\1 {{ item.item.1 }}" dest={{ mktemp_script.stdout }} state=present  insertafter=EOF backrefs=True regexp='(ifup .*)'
+  with_items: "{{ bond_port_result.results }}"
+  when: bond_port_result is defined and 'results' in bond_port_result and item.changed
+
+- lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
+  with_items: "{{ bond_result.results }}"
+  when: bond_result is defined and 'results' in bond_result and item.changed
+
+- lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
+  with_items: "{{ vlan_result.results }}"
+  when: vlan_result is defined and item.changed
+
+- lineinfile: line="\1 {{ item.item.device }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
+  with_items: "{{ bridge_result.results }}"
+  when: bridge_result is defined and 'results' in bridge_result and item.changed
+
+- lineinfile: line="\1 {{ item.item.1 }}" dest={{ mktemp_script.stdout }} state=present insertafter=EOF backrefs=True regexp='(ifup .*)'
+  with_items: "{{ bridge_port_result.results }}"
+  when: bridge_port_result is defined and 'results' in bridge_port_result and item.changed
+
+# Execute configuration change
+- name: Execute Network Restart
+  shell: bash {{ mktemp_script.stdout }} | true
+
+# Cleanup
+- name: Cleanup Network Restart script
+  file: path={{ mktemp_script.stdout }} state=absent

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,4 @@
 ---
-
 network_pkgs:
   - python-selinux
   - bridge-utils

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,3 @@
 ---
 env:
- RUNLEVEL: 1
-
+  RUNLEVEL: 1


### PR DESCRIPTION
We use this role quite a bit.  We are pinned to an older sha, but would
like to continue to use this role and submit features/fixes.  We are
still on ansible 1.9.6.  Since 1.9 is not EOL, ported this role to 1.9.

* The only 2.x feature being used was blocks, which are better leveraged
  as guards around the include statement.
* Cleaned up tasks whitespace.