### PR TITLE
Bridge port Ansible 2.2 compatibility fix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,9 +47,10 @@
   register: bridge_result
 
 - name: Create the network configuration file for port on the bridge devices
-  template: src=bridge_port_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item }}
-  with_items:
-   - "{{ network_bridge_interfaces | selectattr('bridge_ports', 'defined') | list }}"
+  template: src=bridge_port_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
+  with_subelements:
+    - '{{ network_bridge_interfaces }}'
+    - bridge_ports
   when: network_bridge_interfaces is defined
   register: bridge_port_result
 


### PR DESCRIPTION
Configuring ethernet interfaces to be used as bridge ports did not work with Ansible 2.2 due to some issue with nested lists.