### PR TITLE
Add support for NetworkManager on RHEL based operating systems

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: "Benno Joy, Martin Verges"
+  author: "Benno Joy, Martin Verges, Luke Short"
   company: "AnsibleWorks, First Colo GmbH"
   license: "Simplified BSD License"
   min_ansible_version: 1.9

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,6 +58,51 @@
 - include: restartscript.yml
   when: network_allow_service_restart and ansible_os_family == 'Debian'
 
-- name: Restart on RedHat Systems
-  service: name=network state=restarted
+- name: Checking if the "network" service is enabled
+  service: name=network enabled=yes
+  register: network_service
   when: network_allow_service_restart and ansible_os_family == 'RedHat'
+
+- name: Checking if the "NetworkManager" service is enabled
+  service: name=NetworkManager enabled=yes
+  register: NetworkManager_service
+  when: network_allow_service_restart and ansible_os_family == 'RedHat'
+
+- service: name=network enabled=no
+  when: >
+    network_allow_service_restart
+    and ansible_os_family == 'RedHat'
+    and network_service.changed
+
+- service: name=NetworkManager enabled=no
+  when: >
+    network_allow_service_restart
+    and ansible_os_family == 'RedHat'
+    and NetworkManager_service.changed
+
+- name: Restart the "network" service on Red Hat systems
+  service: name=network state=restarted
+  when: >
+    network_allow_service_restart
+    and ansible_os_family == 'RedHat'
+    and not network_service.changed
+    and NetworkManager_service.changed
+
+- name: Restart the "NetworkManager" service on Red Hat systems
+  service: name=network state=restarted
+  when: >
+    network_allow_service_restart
+    and ansible_os_family == 'RedHat'
+    and network_service.changed
+    and not NetworkManager_service.changed
+
+- name: Restart the "network" and "NetworkManager" service on Red Hat systems
+  service: name={{ item }} state=restarted
+  with_flattened:
+    - network
+    - NetworkManager
+  when: >
+    network_allow_service_restart
+    and ansible_os_family == 'RedHat'
+    and not network_service.changed
+    and not NetworkManager_service.changed


### PR DESCRIPTION
Red Hat Enterprise Linux 7 and the most recent versions of Fedora utilize the newer "NetworkManager" service. It is also possible to run both the "network" and "NetworkManager" service at the same time. "NetworkManager" will also manage legacy ifcfg scripts (unless disabled in the ifcfg file by using "NM_CONTROLLED=no").

This patch will account for if the "network" and/or "NetworkManager" services are being used and restart the required services. Since older versions of RHEL use the "chkconfig" command to see if a service is enabled on boot or not (instead of the newer systemd), I use Ansible to check if the service is enabled for compatibility purposes. I try to enable it, if the module's state changes then we know it was disabled. Then I re-disable it (if it was just enabled) and restart the necessary services. If you, or any other person, has a better way of accomplishing this, let me know. But I have tested this and confirmed it to be working under all scenarios (using network, NetworkManager, or both).