### PR TITLE
For mutlti-interfaced hosts, the default gateway is based on the

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -24,3 +24,11 @@
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces is defined and item.route is defined
+
+- name: Cleanup gateway dev that does not set to the one we want
+  lineinfile: dest=/etc/sysconfig/network regexp="^GATEWAYDEV=(?!{{ gateway_dev }})" state=absent
+  when: gateway_dev is defined
+
+- name: Explicitly set gateway dev    
+  lineinfile: dest=/etc/sysconfig/network line="GATEWAYDEV={{ gateway_dev }}"
+  when: gateway_dev is defined


### PR DESCRIPTION
Interface whose ifcfg script is evaluated last. This sometimes causes
problems.

This PR is to explicitly set gateway dev so network interfaces will
have a predictable behavior.