### PR TITLE
when networkmanager or network service is uninstalled,

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,48 +61,51 @@
 - name: Checking if the "network" service is enabled
   service: name=network enabled=yes
   register: network_service
+  ignore_errors: true
   when: network_allow_service_restart and ansible_os_family == 'RedHat'
+
+- set_fact:
+    network_service_present_enabled: "{{ network_service.failed is
+        not defined and not network_service.changed }}"
+    network_service_present_disabled: "{{ network_service.failed is
+        not defined and network_service.changed }}"
 
 - name: Checking if the "NetworkManager" service is enabled
   service: name=NetworkManager enabled=yes
   register: NetworkManager_service
+  ignore_errors: true
   when: network_allow_service_restart and ansible_os_family == 'RedHat'
+
+- set_fact:
+    NetworkManager_service_present_enabled: "{{
+        NetworkManager_service.failed is not defined and not
+        NetworkManager_service.changed }}"
+    NetworkManager_service_present_disabled: "{{
+        NetworkManager_service.failed is not defined and
+        NetworkManager_service.changed }}"
 
 - service: name=network enabled=no
   when: >
     network_allow_service_restart
     and ansible_os_family == 'RedHat'
-    and network_service.changed
+    and network_service_present_disabled
 
 - service: name=NetworkManager enabled=no
   when: >
     network_allow_service_restart
     and ansible_os_family == 'RedHat'
-    and NetworkManager_service.changed
+    and NetworkManager_service_present_disabled
 
 - name: Restart the "network" service on Red Hat systems
   service: name=network state=restarted
   when: >
     network_allow_service_restart
     and ansible_os_family == 'RedHat'
-    and not network_service.changed
-    and NetworkManager_service.changed
+    and network_service_present_enabled
 
 - name: Restart the "NetworkManager" service on Red Hat systems
   service: name=network state=restarted
   when: >
     network_allow_service_restart
     and ansible_os_family == 'RedHat'
-    and network_service.changed
-    and not NetworkManager_service.changed
-
-- name: Restart the "network" and "NetworkManager" service on Red Hat systems
-  service: name={{ item }} state=restarted
-  with_flattened:
-    - network
-    - NetworkManager
-  when: >
-    network_allow_service_restart
-    and ansible_os_family == 'RedHat'
-    and not network_service.changed
-    and not NetworkManager_service.changed
+    and NetworkManager_service_present_enabled


### PR DESCRIPTION
i.e. systemctl status shows not-found/inactive/dead/,
ansible playbook will be interrupted by "Could not find the
requested service NetworkManager: cannot enable" error.

This PR introduces addtional variables to handle this
case.