### PR TITLE
Restart the right service and not one that might not exist

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -152,7 +152,7 @@
 
 - name: Restart the "NetworkManager" service on Red Hat systems
   service:
-    name: network
+    name: NetworkManager
     state: restarted
   when: >
     (network_allow_service_restart


### PR DESCRIPTION
The role carefully determines whether `network` or `NetworkManager` is in use on a given system... and then unconditionally restarts `network`. This is presumably just a typo.